### PR TITLE
feat: Add redirect for fedearlistapp.18f.gov to pages.cloud.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,6 @@ services:
       - app:requests.18f.gov
       - app:c2.18f.gov
       - app:www.findtreatment.gov
-      - app:federalist-docs.18f.gov
       - app:private-eye.18f.gov
       # - app:atf-eregs.18f.gov
       - app:agile-labor-categories.18f.gov
@@ -89,3 +88,4 @@ services:
       - app:portfolios.18f.gov
       - app:fac.gov
       - app:usdigitalregistry.digitalgov.gov
+      - app:federalistapp.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -375,12 +375,12 @@ server {
   return 301 https://$target_domain$request_uri;
 }
 
-# federalist-docs.18f.gov to federalist.18f.gov
+# federalistapp.18f.gov to pages.cloud.gov
 server {
   listen {{ PORT }};
-  set $target_domain federalist.18f.gov;
-  server_name federalist-docs.18f.gov;
-  return 301 https://$target_domain;
+  set $target_domain pages.cloud.gov;
+  server_name federalistapp.18f.gov;
+  return 301 https://$target_domain$request_uri;
 }
 
 # private-eye.18f.gov to github.com/18f/private-eye


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add redirect for federalistapp.18f.gov to pages.cloud.gov

## Security considerations

Redirect for deprecated endpoints
