### PR TITLE
chore: Remove federalist-docs.18f.gov redirect

### DIFF
--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -35,7 +35,6 @@ routes:
 - route: requests.18f.gov
 - route: c2.18f.gov
 - route: www.findtreatment.gov
-- route: federalist-docs.18f.gov
 {# - route: atf-eregs.18f.gov #}
 - route: private-eye.18f.gov
 - route: agile-labor-categories.18f.gov


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove old federalist-docs.18f.gov redirect

## Security considerations
Deprecated URL
