### PR TITLE
Add design.login.gov redirect configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       - app:www.search.gov
       - app:ads.18f.gov
       - app:usability.gov
+      - app:design.login.gov
       - app:developer.login.gov
       - app:partners.login.gov
       - app:components.designsystem.digital.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -535,3 +535,10 @@ server {
     return 301 https://www.login.gov/partners/state-and-local/;
   }
 }
+
+# design.login.gov to www.login.gov
+server {
+  listen {{ PORT }};
+  server_name design.login.gov;
+  return 301 https://www.login.gov/;
+}

--- a/test/integration/test_federalist_redirects.js
+++ b/test/integration/test_federalist_redirects.js
@@ -37,6 +37,7 @@ const expectedRedirects = [
   { from: 'partners.login.gov/sandbox', to: 'developers.login.gov', redirectCode: 301, noPath: true },
   { from: 'partners.login.gov/state-and-local/', to: 'www.login.gov/partners/state-and-local', redirectCode: 301, noPath: true },
   { from: 'partners.login.gov/state-and-local', to: 'www.login.gov/partners/state-and-local', redirectCode: 301, noPath: true },
+  { from: 'design.login.gov', to: 'www.login.gov', redirectCode: 301, noPath: true },
   { from: 'usdigitalregistry.digitalgov.gov', to: 'touchpoints.app.cloud.gov/registry', redirectCode: 301, noPath: true },
 ];
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds configuration to redirect https://design.login.gov to https://www.login.gov

Similar to previous #200

## Security considerations

N/A