### PR TITLE
Fixing derisking and product redirected subdomains

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -229,8 +229,8 @@ server {
   }
 
   location ~ ^/derisking/? {
-    rewrite ^/derisking/(.*)$ $scheme://derisking.18f.gov/$1;
-    return 302 $scheme://derisking.18f.gov/;
+    rewrite ^/derisking/(.*)$ $scheme://derisking-guide.18f.gov/$1;
+    return 302 $scheme://derisking-guide.18f.gov/;
   }
 
   location ~ ^/eng-hiring/? {
@@ -244,8 +244,8 @@ server {
   }
 
   location ~ ^/product/? {
-    rewrite ^/product/(.*)$ $scheme://product.18f.gov/$1;
-    return 302 $scheme://product.18f.gov/;
+    rewrite ^/product/(.*)$ $scheme://product-guide.18f.gov/$1;
+    return 302 $scheme://product-guide.18f.gov/;
   }
 
   location ~ ^/ux-guide/? {


### PR DESCRIPTION
## Changes proposed in this pull request:
It turns out two of our redirects were slightly incorrect:
- `guides.18f.gov/product/*` should redirect to `product-guide.18f.gov/*` (was `product.18f.gov`)
- `guides.18f.gov/derisking/*` should redirect to`derisking-guide.18f.gov/*` (was `derisking.18f.gov`)
- 

## Security considerations
There are no security issues, since the routes we are redirecting are still not actually live
