### PR TITLE
Updating agile guide subdomain requests to redirect and rewrite

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -537,7 +537,7 @@ server {
 # agile.18f.gov to guides.18f.gov/agile/
 server {
   listen {{ PORT }};
-  server_name agile.login.gov;
+  server_name agile.18f.gov;
 
   location / {
     return 301 https://guides.18f.gov/agile$uri;

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -533,3 +533,13 @@ server {
   server_name design.login.gov;
   return 301 https://www.login.gov/;
 }
+
+# agile.18f.gov to guides.18f.gov/agile/
+server {
+  listen {{ PORT }};
+  server_name agile.login.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/agile$uri;
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Permanently redirect all requests to `agile.18f.gov` to `guides.18f.gov/agile`
- Ensure that additional sub-paths are passed correctly during the redirect, ie `agile.18f.gov/something-here` redirects to `guides.18f.gov/agile/something-here`

## Security considerations
There are no known security considerations
