### PR TITLE
Permanently redirect 18F brand guide to guides.18f.gov/brand/

### DIFF
--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -543,3 +543,13 @@ server {
     return 301 https://guides.18f.gov/agile$uri;
   }
 }
+
+# brand.18f.gov to guides.18f.gov/brand/
+server {
+  listen {{ PORT }};
+  server_name brand.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/brand$uri;
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds 301 redirects for pages on `brand.18f.gov` to `guides.18f.gov/brand/`

## Security considerations

None
