### PR TITLE
Permanently redirect 18F brand guide to guides.18f.gov/brand (main branch)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,3 +88,4 @@ services:
       - app:usdigitalregistry.digitalgov.gov
       - app:federalistapp.18f.gov
       - app:agile.18f.gov
+      - app:brand.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -543,3 +543,13 @@ server {
     return 301 https://guides.18f.gov/agile$uri;
   }
 }
+
+# brand.18f.gov to guides.18f.gov/brand/
+server {
+  listen {{ PORT }};
+  server_name brand.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/brand$uri;
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds 301 redirects for pages on `brand.18f.gov` to `guides.18f.gov/brand/`, similar to #226 
- Adding `brand.18f.gov` to `docker-compose.yml` made all integration tests pass

## Security considerations

None 
