### PR TITLE
Permanently redirect 18F content, derisking, ux guides

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,3 +89,6 @@ services:
       - app:federalistapp.18f.gov
       - app:agile.18f.gov
       - app:brand.18f.gov
+      - app:content-guide.18f.gov
+      - app:derisking-guide.18f.gov
+      - app:ux-guide.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -553,3 +553,33 @@ server {
     return 301 https://guides.18f.gov/brand$uri;
   }
 }
+
+# content-guide.18f.gov to guides.18f.gov/content-guide/
+server {
+  listen {{ PORT }};
+  server_name content-guide.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/content-guide$uri;
+  }
+}
+
+# derisking-guide.18f.gov to guides.18f.gov/derisking/
+server {
+  listen {{ PORT }};
+  server_name derisking-guide.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/derisking$uri;
+  }
+}
+
+# ux-guide.18f.gov to guides.18f.gov/ux-guide/
+server {
+  listen {{ PORT }};
+  server_name ux-guide.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/ux-guide$uri;
+  }
+}


### PR DESCRIPTION
⚠️ Will be ready for merge Thurs, Dec 7

## Changes proposed in this pull request:

- Adds 301 redirects for `content-guide.18f.gov`, `derisking-guide.18f.gov`, and `ux-guide.18f.gov`
- Makes integration tests pass with new redirects
- 

## Security considerations

None
