### PR TITLE
Permanently redirect 18f guides: accessibility, eng-hiring, engineering and product

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,3 +92,7 @@ services:
       - app:content-guide.18f.gov
       - app:derisking-guide.18f.gov
       - app:ux-guide.18f.gov
+      - app:accessibility.18f.gov
+      - app:eng-hiring.18f.gov
+      - app:engineering.18f.gov
+      - app:product-guide.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -534,6 +534,16 @@ server {
   return 301 https://www.login.gov/;
 }
 
+# accessibility.18f.gov to guides.18f.gov/accessibility
+server {
+  listen {{ PORT }};
+  server_name accessibility.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/accessibility$uri;
+  }
+}
+
 # agile.18f.gov to guides.18f.gov/agile/
 server {
   listen {{ PORT }};
@@ -571,6 +581,36 @@ server {
 
   location / {
     return 301 https://guides.18f.gov/derisking$uri;
+  }
+}
+
+# eng-hiring.18f.gov to guides.18f.gov/eng-hiring
+server {
+  listen {{ PORT }};
+  server_name eng-hiring.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/eng-hiring$uri;
+  }
+}
+
+# engineering.18f.gov to guides.18f.gov/engineering
+server {
+  listen {{ PORT }};
+  server_name engineering.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/engineering$uri;
+  }
+}
+
+# product-guide.18f.gov to guides.18f.gov/product
+server {
+  listen {{ PORT }};
+  server_name product-guide.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/product$uri;
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds 301 redirects for:
- `accessibility.18f.gov`
- `eng-hiring.18f.gov`
- `engineering.18f.gov`
- `product-guide.18f.gov`

Also makes integration tests pass with new redirects.

## Security considerations

None
