### PR TITLE
re-enable atf-eregs redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - app:c2.18f.gov
       - app:www.findtreatment.gov
       - app:private-eye.18f.gov
-      # - app:atf-eregs.18f.gov
+      - app:atf-eregs.18f.gov
       - app:agile-labor-categories.18f.gov
       - app:handbook.18f.gov
       - app:frontend.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -383,12 +383,12 @@ server {
 }
 
 # atf-eregs.18f.gov to regulations.atf.gov
-{# server {
+server {
   listen {{ PORT }};
   set $target_domain regulations.atf.gov;
   server_name atf-eregs.18f.gov;
   return 301 https://$target_domain;
-} #}
+} 
 
 # agile-labor-categories.18f.gov to derisking-guide.18f.gov
 server {

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -35,7 +35,7 @@ routes:
 - route: requests.18f.gov
 - route: c2.18f.gov
 - route: www.findtreatment.gov
-{# - route: atf-eregs.18f.gov #}
+- route: atf-eregs.18f.gov
 - route: private-eye.18f.gov
 - route: agile-labor-categories.18f.gov
 - route: handbook.18f.gov


### PR DESCRIPTION
## Changes proposed in this pull request:

- re-enable the permanent redirect from https://atf-eregs.18f.gov/ to https://regulations.atf.gov/ 

## Security considerations

- None

