### PR TITLE
chore: Update CI to use hardened resource images

### DIFF
--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -93,12 +93,6 @@ start_docker() {
 
   local docker_opts="${DOCKER_OPTS:-}"
 
-  # Pass through `--garden-mtu` from gardian container
-  if [[ "${docker_opts}" != *'--mtu'* ]]; then
-    local mtu="$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)"
-    docker_opts+=" --mtu ${mtu}"
-  fi
-
   # Use Concourse's scratch volume to bypass the graph filesystem by default
   if [[ "${docker_opts}" != *'--data-root'* ]] && [[ "${docker_opts}" != *'--graph'* ]]; then
     docker_opts+=' --data-root /scratch/docker'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,11 +11,16 @@ env-cf: &env-cf
   CF_STACK: cflinuxfs4
 
 node-image: &node-image
-  type: docker-image
-  source:
-    repository: node
-    tag: 20-bullseye-slim
-    
+  platform: linux
+  image_resource:
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr-aws-key))
+      aws_secret_access_key: ((ecr-aws-secret))
+      repository: pages-node-v20
+      aws_region: us-gov-west-1
+      tag: latest
+
 cf-image: &cf-image
   platform: linux
   image_resource:
@@ -30,9 +35,7 @@ cf-image: &cf-image
 test-redirects: &test-redirects
   - task: install-dependencies
     config:
-      platform: linux
-      image_resource:
-        <<: *node-image
+      <<: *node-image
       inputs: [name: src]
       outputs: [name: src]
       run:
@@ -42,9 +45,7 @@ test-redirects: &test-redirects
 
   - task: build
     config:
-      platform: linux
-      image_resource:
-        <<: *node-image
+      <<: *node-image
       inputs: [name: src]
       outputs: [name: src]
       run:
@@ -58,9 +59,13 @@ test-redirects: &test-redirects
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
-              repository: karlkfi/concourse-dcind
+              aws_access_key_id: ((ecr-aws-key))
+              aws_secret_access_key: ((ecr-aws-secret))
+              repository: pages-dind-v25
+              aws_region: us-gov-west-1
+              tag: latest
           inputs:
             - name: src
           run:
@@ -138,9 +143,6 @@ jobs:
         resource: src
         trigger: true
         params: { depth: 1 }
-      - put: gh-status
-        inputs: [src]
-        params: { state: pending }
       - do: *test-redirects
 
       - task: deploy
@@ -166,9 +168,6 @@ jobs:
 
     on_failure:
       in_parallel:
-        - put: gh-status
-          inputs: [src]
-          params: { state: failure }
         - put: slack
           params:
             text: |
@@ -179,9 +178,6 @@ jobs:
             icon_url: ((slack-icon-url))
     on_success:
       in_parallel:
-        - put: gh-status
-          inputs: [src]
-          params: { state: success }
         - put: slack
           params:
             text: |
@@ -250,31 +246,44 @@ resources:
     source:
       url: ((slack-webhook-url))
 
-  - name: gh-status
-    type: cogito
-    check_every: 1h
-    source:
-      owner: cloud-gov
-      repo: pages-redirects
-      access_token: ((gh-access-token))
-      context_prefix: concourse
 
 ############################
 #  RESOURCE TYPES
 
 resource_types:
-  - name: cogito
-    type: docker-image
-    check_every: 24h
-    source:
-      repository: pix4d/cogito
 
-  - name: pull-request
-    type: docker-image
+  - name: git
+    type: registry-image
     source:
-      repository: teliaoss/github-pr-resource
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
   - name: slack-notification
-    type: docker-image
+    type: registry-image
     source:
-      repository: cfcommunity/slack-notification-resource
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: slack-notification-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: pull-request
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: github-pr-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: time
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: time-resource
+      aws_region: us-gov-west-1
+      tag: latest


### PR DESCRIPTION
Closes #236 


## Changes proposed in this pull request:

- Adds hardened node, time, git, and docker in docker (dind) images to the resource types and tasks in CI

## Security considerations
Add hardened resource type images to CI.
