### PR TITLE
Redirect methods.18f.gov URLs to guides.18f.gov/methods

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,3 +96,4 @@ services:
       - app:eng-hiring.18f.gov
       - app:engineering.18f.gov
       - app:product-guide.18f.gov
+      - app:methods.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -623,3 +623,13 @@ server {
     return 301 https://guides.18f.gov/ux-guide$uri;
   }
 }
+
+# methods.18f.gov to guides.18f.gov/methods/
+server {
+  listen {{ PORT }};
+  server_name methods.18f.gov;
+
+  location / {
+    return 301 https://guides.18f.gov/methods$uri;
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Set up a permanent redirect from https://methods.18f.gov to https://guides.18f.gov/methods
- This is [step 5](https://docs.google.com/document/d/19b1Y2pSyw1EjXzc2XmL-qXqQCfqiVQLkypOO8zJKUKw/edit#heading=h.73q64d4ws48t) of the Migration guide

## Security considerations

This is considered a "soft launch" of the site. 
