### PR TITLE
Update manifest-prod.yml.njk with methods.18f.gov route

### DIFF
--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -52,6 +52,7 @@ routes:
 - route: govconnect.18f.gov
 - route: portfolios.18f.gov
 - route: fac.gov
+- route: methods.18f.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
## Changes proposed in this pull request:

Missed this last step as part of #239. This change adds the app route `methods.18f.gov` to the manifest. 

