### PR TITLE
chore(ci): Switch to general-task and registry-image for CI jobs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -28,9 +28,9 @@ cf-image: &cf-image
     source:
       aws_access_key_id: ((ecr-aws-key))
       aws_secret_access_key: ((ecr-aws-secret))
-      repository: harden-concourse-task
+      repository: general-task
       aws_region: us-gov-west-1
-      tag: ((harden-concourse-task-tag))
+      tag: latest
 
 test-redirects: &test-redirects
   - task: install-dependencies
@@ -285,5 +285,14 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: time-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: registry-image
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: registry-image-resource
       aws_region: us-gov-west-1
       tag: latest


### PR DESCRIPTION
Related to https://github.com/cloud-gov/pages-core/issues/4394

## Changes proposed in this pull request:
- Switches to use the general-task image
- Adds registry-image resource type

## security considerations
Related to adding hardened containers
