### PR TITLE
Redirect for accessibility.digital.gov to digital.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       - app:derisking-guide.18f.gov
       - app:ux-guide.18f.gov
       - app:accessibility.18f.gov
+      - app:accessibility.digital.gov
       - app:eng-hiring.18f.gov
       - app:engineering.18f.gov
       - app:product-guide.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -534,6 +534,14 @@ server {
   return 301 https://www.login.gov/;
 }
 
+# accessibility.digital.gov to digital.gov/guides/accessibility-for-teams
+server {
+  listen {{ PORT }};
+  set $target_domain www.digital.gov/guides/accessibility-for-teams;
+  server_name accessibility.digital.gov;
+  return 301 https://$target_domain;
+}
+
 # accessibility.18f.gov to guides.18f.gov/accessibility
 server {
   listen {{ PORT }};

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -10,6 +10,7 @@ routes:
 - route: pages-redirects.app.cloud.gov
 - route: pif.gov
 - route: apply.pif.gov
+- route: accessibility.digital.gov
 - route: www.pif.gov
 - route: paygap.pif.gov
 - route: tophealth.pif.gov


### PR DESCRIPTION
## Changes proposed in this pull request:

- 
- 
- 

## Security considerations

[Note the any security considerations here, or make note of why there are none]
