### PR TITLE
Redirect identityequitystudy.gsa.gov to the main gsa website

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,3 +99,4 @@ services:
       - app:engineering.18f.gov
       - app:product-guide.18f.gov
       - app:methods.18f.gov
+      - app:identityequitystudy.gsa.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -652,3 +652,13 @@ server {
     return 301 https://guides.18f.gov/methods$uri;
   }
 }
+
+# identityequitystudy.gsa.gov to gsa.gov...
+server {
+  listen {{ PORT }};
+  server_name identityequitystudy.gsa.gov;
+
+  location / {
+    return 301 https://www.gsa.gov/governmentwide-initiatives/diversity-equity-inclusion-and-accessibility/equity-study-on-remote-identity-proofing
+  }
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -54,6 +54,7 @@ routes:
 - route: govconnect.18f.gov
 - route: portfolios.18f.gov
 - route: fac.gov
+- route: identityequitystudy.gsa.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Redirect identityequitystudy.gsa.gov to the Equity study page on the GSA DEIA portal 
- See #246 

## Security considerations

none
