### PR TITLE
fix(ci): Add CF_APP_NAME param to nightly restage task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -114,6 +114,7 @@ jobs:
         file: pipeline-tasks/tasks/restage.yml
         params:
           _: #@ template.replace(data.values.env_cf_redirects)
+          CF_APP_NAME: pages-redirects
   #@ end
 
 #!  RESOURCES


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds CF_APP_NAME param to successfully run nightly restage task

## Security considerations

None