### PR TITLE
Update nginx.conf.njk

### DIFF
--- a/templates/nginx.conf.njk
+++ b/templates/nginx.conf.njk
@@ -47,6 +47,7 @@ http {
     rewrite ^/intake/.* https://18f.gsa.gov/contact/ redirect;
     rewrite ^/designstandards/.* https://standards.usa.gov/ redirect;
     rewrite ^/joining-18f/.* https://18f.gsa.gov/join/ redirect;
+    rewrite ^/chat/.* https://docs.google.com/forms/d/e/1FAIpQLSfFoLTRV00g1iIEZv404wJ0BRwNc6CPKbyXMCeXLjDKDv9g4Q/viewform?usp=sf_link redirect;
     # -- end custom pages.18f.gov redirects
 
     # For everything else, show an error message


### PR DESCRIPTION
Added a redirect to restore the 18f.gov/chat form that USWDS + others need, but keeps chat.18f.gov removed

## Changes proposed in this pull request:

- 
- 
- 

## Security considerations

[Note the any security considerations here, or make note of why there are none]
