### PR TITLE
feat: Add demo.pra.digital.gov redirect to pra.digital.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,3 +101,4 @@ services:
       - app:methods.18f.gov
       - app:identityequitystudy.gsa.gov
       - app:join.tts.gsa.gov
+      - app:demo.pra.digital.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -696,3 +696,11 @@ server {
   }
 
 }
+
+# demo.pra.digital.gov to pra.digital.gov
+server {
+  listen {{ PORT }};
+  set $target_domain pra.digital.gov;
+  server_name demo.pra.digital.gov;
+  return 301 https://$target_domain$request_uri;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -56,6 +56,7 @@ routes:
 - route: fac.gov
 - route: identityequitystudy.gsa.gov
 - route: join.tts.gsa.gov
+- route: demo.pra.digital.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
In favor of #260 

## Changes proposed in this pull request:

- Adds demo.pra.digital.gov redirect to pra.digital.gov

## Security considerations

None
