### PR TITLE
chore: Remove defunct c2.18f.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,6 @@ services:
       - app:fedspendingtransparency.18f.gov
       - app:cap.18f.gov
       - app:requests.18f.gov
-      - app:c2.18f.gov
       - app:www.findtreatment.gov
       - app:private-eye.18f.gov
       - app:atf-eregs.18f.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -377,13 +377,6 @@ server {
   return 301 https://$target_domain;
 }
 
-server {
-  listen {{ PORT }};
-  set $target_domain docs.google.com/forms/d/e/1FAIpQLSd-GoOE9xWWfJvdZNRP3SE7mj5ysI_RfM8brxdG8YpyJV9yKA/viewform;
-  server_name c2.18f.gov;
-  return 301 https://$target_domain;
-}
-
 # www.findtreatment.gov to findtreatment.gov
 server {
   listen {{ PORT }};

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -34,7 +34,6 @@ routes:
 - route: fedspendingtransparency.18f.gov
 - route: cap.18f.gov
 - route: requests.18f.gov
-- route: c2.18f.gov
 - route: www.findtreatment.gov
 - route: atf-eregs.18f.gov
 - route: private-eye.18f.gov


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes c2.18f.gov since the DNS was removed https://github.com/18F/dns/pull/713

## Security considerations
Removing a supported redirect
