### PR TITLE
feat: Add code.gov redirect to digital.gov

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,3 +101,7 @@ services:
       - app:identityequitystudy.gsa.gov
       - app:join.tts.gsa.gov
       - app:demo.pra.digital.gov
+      - app:code.gov
+      - app:www.code.gov
+      - app:staging.code.gov
+      - app:api.code.gov

--- a/templates/_federalist-redirects.njk
+++ b/templates/_federalist-redirects.njk
@@ -667,3 +667,35 @@ server {
   server_name demo.pra.digital.gov;
   return 301 https://$target_domain$request_uri;
 }
+
+# code.gov to digital.gov
+server {
+  listen {{ PORT }};
+  set $target_domain digital.gov;
+  server_name code.gov;
+  return 301 https://$target_domain;
+}
+
+# www.code.gov to digital.gov
+server {
+  listen {{ PORT }};
+  set $target_domain digital.gov;
+  server_name www.code.gov;
+  return 301 https://$target_domain;
+}
+
+# staging.code.gov to digital.gov
+server {
+  listen {{ PORT }};
+  set $target_domain digital.gov;
+  server_name staging.code.gov;
+  return 301 https://$target_domain;
+}
+
+# api.code.gov to digital.gov
+server {
+  listen {{ PORT }};
+  set $target_domain digital.gov;
+  server_name api.code.gov;
+  return 301 https://$target_domain;
+}

--- a/templates/manifest-prod.yml.njk
+++ b/templates/manifest-prod.yml.njk
@@ -56,6 +56,10 @@ routes:
 - route: identityequitystudy.gsa.gov
 - route: join.tts.gsa.gov
 - route: demo.pra.digital.gov
+- route: code.gov
+- route: www.code.gov
+- route: staging.code.gov
+- route: api.code.gov
 {% for page in PAGE_CONFIGS -%}
 - route: {{ page.to }}.{{ page.toDomain }}
 {% endfor -%}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add code.gov, www.code.gov, staging.code.gov, api.code.gov redirects to digital.gov

## Security considerations

Adds redirects
