### PR TITLE
chore: Remove federalistapp.18f.gov redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,6 @@ services:
       - app:govconnect.18f.gov
       - app:portfolios.18f.gov
       - app:fac.gov
-      - app:federalistapp.18f.gov
       - app:agile.18f.gov
       - app:brand.18f.gov
       - app:content-guide.18f.gov


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes federalistapp.18f.gov redirect since it is deprecated.

## Security considerations

Removing deprecated redirect.